### PR TITLE
♻️ docker-compose.ymlをシンプルにする

### DIFF
--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -53,7 +53,7 @@ development:
   compile: true
 
   # Verifies that correct packages and versions are installed by inspecting package.json, yarn.lock, and node_modules
-  check_yarn_integrity: true
+  check_yarn_integrity: false
 
   # Reference: https://webpack.js.org/configuration/dev-server/
   dev_server:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       - '3002:3002'
 
   postgres:
-    image: postgres:12.1
+    image: postgres:11.5
     volumes:
       - .dockerdev/init_postgres/:/docker-entrypoint-initdb.d/
       - .dockerdev/.psqlrc:/root/.psqlrc:ro

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       bash -c "bundle install &&
       yarn install --check-files &&
       bin/rake db:create &&
+      bin/rake db:migrate &&
       rm -f tmp/pids/server.pid &&
       bundle exec rails server -b 0.0.0.0"
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,9 +24,6 @@ x-backend-volumes: &backend-volumes
     - .dockerdev/.bashrc:/root/.bashrc:ro
     - .:/app:cached
     - bundle:/bundle
-    - rails_cache:/app/tmp/cache
-    - node_modules:/app/node_modules
-    - packs:/app/public/packs
 
 # Rubyのサービスで共有する振る舞いを提供する
 x-backend: &backend
@@ -35,9 +32,7 @@ x-backend: &backend
   tty: true 
   environment:
     <<: *env
-    REDIS_URL: redis://redis:6379/
     BOOTSNAP_CACHE_DIR: /bundle/bootsnap
-    WEBPACKER_DEV_SERVER_HOST: webpacker
     HISTFILE: /app/log/.bash_history
     PSQL_HISTFILE: /app/log/.psql_history
     EDITOR: vi
@@ -45,45 +40,18 @@ x-backend: &backend
     WEB_CONCURRENCY: ${WEB_CONCURRENCY:-1}
   depends_on:
     - postgres
-    - redis
 
 services:
-  rails:
+  runner:
     <<: *backend
     <<: *backend-volumes
     command: >
       bash -c "bundle install &&
-      yarn install --check-files &&
       bin/rake db:create &&
       bin/rake db:migrate &&
-      rm -f tmp/pids/server.pid &&
-      bundle exec rails server -b 0.0.0.0"
-    ports:
-      - '3000:3000'
-
-  runner:
-    <<: *backend
-    <<: *backend-volumes
-    command: /bin/bash
+      bash"
     ports:
       - '3002:3002'
-
-  redis:
-    image: redis:5.0-alpine
-    volumes:
-      - redis:/data
-    ports:
-      - 6379
-
-  webpacker:
-    <<: *app
-    <<: *backend-volumes
-    command: ./bin/webpack-dev-server
-    ports:
-      - '3035:3035'
-    environment:
-      <<: *env
-      WEBPACKER_DEV_SERVER_HOST: 0.0.0.0
 
   postgres:
     image: postgres:12.1
@@ -100,7 +68,3 @@ services:
 volumes:
   postgres:
   bundle:
-  node_modules:
-  rails_cache:
-  packs:
-  redis:


### PR DESCRIPTION
## 概要

DBの管理だけなのでWebアプリケーションとして必要なものをdocker-compose.ymlから排除しシンプルにする

## 修正内容

- 必要のないserviceは削除する
- serviceをrunnerのみにして立ち上げればすぐにDBの開発をできるようにする
- RDSとPostgreSQLのバージョンが不一致だったので合わせた
- Webpackerを使用していないがyarnのチェックが入ってうざかったのでチェックが入らないようにした
    - 参考にしたURL：[webpacker の check_yarn_integrity オプションについて調べてみた - Qiita](https://qiita.com/gotchane/items/0759c89382f5ce91d769)

 ## 確認事項

- [x] CIが通過していること
