### PR TITLE
♻️ 踏み台サーバーの名称をAWSでの呼称と合わせる

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -162,7 +162,7 @@ commands:
           #   The authenticity of host 'hoge (fuga)' can't be established.
           #   RSA key fingerprint is hoge
           #   Are you sure you want to continue connecting (yes/no)? 
-          command: ssh -o StrictHostKeyChecking=no -f -N -L ${EROGE_RELEASE_DB_LOCAL_PORT}:${EROGE_RELEASE_DB_HOST}:${EROGE_RELEASE_DB_PORT} ${BASTION_USER}@${BASTION_HOST}
+          command: ssh -o StrictHostKeyChecking=no -f -N -L ${EROGE_RELEASE_DB_LOCAL_PORT}:${EROGE_RELEASE_DB_HOST}:${EROGE_RELEASE_DB_PORT} ${STEPPING_STONE_SERVER_USER}@${STEPPING_STONE_SERVER_HOST}
   deploy-notification:
     steps:
       - slack/status:


### PR DESCRIPTION
## 概要

踏み台サーバーの名称をAWSでの呼称と合わせる

## 修正内容

- CircleCIで使用していた環境変数名を変更
- 名称を変更したのでCircleCIでの設定も変更する

## 確認事項

- [x] CIが通過していること
