### PR TITLE
🚨 Dockerの静的解析ツール hadolint の実装

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,7 @@
 version: 2.1
 orbs:
   slack: circleci/slack@3.4.2
+  docker: circleci/docker@1.0.1
 executors:
   base:
     docker:
@@ -230,6 +231,12 @@ workflows:
     jobs:
       - setup
       - lint:
+          requires:
+            - setup
+      # 詳しくはドキュメントを確認
+      #   https://circleci.com/orbs/registry/orb/circleci/docker
+      - docker/hadolint:
+          dockerfiles: .dockerdev/Dockerfile
           requires:
             - setup
       - test:

--- a/.dockerdev/Dockerfile
+++ b/.dockerdev/Dockerfile
@@ -6,7 +6,13 @@ ARG NODE_MAJOR
 ARG YARN_VERSION
 ARG BUNDLER_VERSION
 
+# パイプライン内のコマンドがエラーとなった時に中断するオプション
+#   これがないとパイプライン時に途中で失敗しているが最後が成功しているような時は
+#   成功とみなされてしまうため、この設定が必要である
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Common dependencies
+# hadolint ignore=DL3008
 RUN apt-get update -qq \
   && DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     build-essential \
@@ -35,6 +41,7 @@ RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add - \
 
 # Install dependencies
 COPY .dockerdev/Aptfile /tmp/Aptfile
+# hadolint ignore=SC2002,SC2046,DL3008
 RUN apt-get update -qq && DEBIAN_FRONTEND=noninteractive apt-get -yq dist-upgrade && \
     DEBIAN_FRONTEND=noninteractive apt-get install -yq --no-install-recommends \
     libpq-dev \


### PR DESCRIPTION
## 概要

Dockerfileを常に一定の基準で保たれるようにするためにDockerfile用の静的コード解析を追加する

## 修正内容

- CircleCI に hadolint を追加し Dockerfileも静的コード解析されるようにする
- hadolint の指摘通りにDockerfileを修正
    - 修正出来ないところは一旦放置する

## 確認事項

- [x] CIが通過していること
