### PR TITLE
🔧  コマンドに設定情報を渡しており管理が煩雑だったため schemaspy.properties に設定を逃がす

### DIFF
--- a/.dockerdev/schemaspy/schemaspy.properties
+++ b/.dockerdev/schemaspy/schemaspy.properties
@@ -1,0 +1,7 @@
+schemaspy.t=pgsql
+schemaspy.host=postgres
+schemaspy.port=5432
+schemaspy.db=dev_eroge_release
+schemaspy.s=public
+schemaspy.u=root
+schemaspy.connprops=useSSL\\=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,16 +69,9 @@ services:
     image: schemaspy/schemaspy
     volumes:
       - .dockerdev/schemaspy/output/:/output
+      - .dockerdev/schemaspy/schemaspy.properties:/schemaspy.properties
     command: >
       java -jar schemaspy.jar
-      -t pgsql
-      -host ${DB_HOST:-postgres}
-      -port ${DB_PORT:-5432}
-      -db ${DB_NAME:-dev_eroge_release}
-      -u ${DB_USER:-root}
-      -p ${DB_PASS:-}
-      -s ${DB_NAME:-public}
-      -connprops useSSL\\\\=false
     depends_on:
       - postgres
 


### PR DESCRIPTION
## 概要

schemaspy の起動にわたす引数の管理が煩雑だったため、設定を逃がす

## 修正内容

- schemaspy.properties に設定を逃がす

## 確認事項

- [ ] CIが通過していること
