### PR TITLE
✨  AWS のリソースを Terraform 化する 〜 netwrok 編 〜

### DIFF
--- a/terraform/.gitignore
+++ b/terraform/.gitignore
@@ -1,0 +1,39 @@
+# Created by https://www.toptal.com/developers/gitignore/api/terraform
+# Edit at https://www.toptal.com/developers/gitignore?templates=terraform
+
+### Terraform ###
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Crash log files
+crash.log
+
+# Exclude all .tfvars files, which are likely to contain sentitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+#
+*.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc
+
+# End of https://www.toptal.com/developers/gitignore/api/terraform

--- a/terraform/bin/config/config-bucket-encryption.json
+++ b/terraform/bin/config/config-bucket-encryption.json
@@ -1,0 +1,7 @@
+{
+    "Rules": [{
+        "ApplyServerSideEncryptionByDefault": {
+            "SSEAlgorithm": "AES256"
+        }
+    }]
+}

--- a/terraform/bin/config/config-public-access-block.json
+++ b/terraform/bin/config/config-public-access-block.json
@@ -1,0 +1,6 @@
+{
+    "BlockPublicAcls": true,
+    "IgnorePublicAcls": true,
+    "BlockPublicPolicy": true,
+    "RestrictPublicBuckets": true
+}

--- a/terraform/bin/delete_component_s3.sh
+++ b/terraform/bin/delete_component_s3.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+# 実行スクリプトのフォルダへ移動（この記述をすることで実行場所を選ばないスクリプトになる）
+cd `dirname $0`
+
+printf "＜Componentの削除手順＞\n1. providers.tfファイル以外を削除しデプロイする \n2. delete_component_s3.shを実行しComponentのtfstateファイルを削除する \n3. Componentのフォルダごとを削除 \n\n"
+
+# 対象のComponentのproviders.tfファイル内のbackendの設定値を入力する事を想定しています
+read -p "S3のディレクトリ削除で使用するprofile名を入力してください: " PROFILE_NAME
+read -p "削除対象のComponent名を入力して下さい: " COMPONENT_NAME
+read -p "削除対象のComponentのtfstateファイルが存在するバケット名(bucketの値)を入力して下さい: " BUCKET_NAME
+
+# 対象のComponentのtfstateファイルを管理しているディレクトリを削除する
+DELETE_S3_PATH="s3://${BUCKET_NAME}/${COMPONENT_NAME}"
+DELETE_DIR_PATH="./../components/${COMPONENT_NAME}"
+printf "\n「${COMPONENT_NAME}」Componentsを削除します\n"
+printf "\n S3: ${DELETE_S3_PATH}\nDir: ${DELETE_DIR_PATH}\n\n"
+read -p "削除を実行する場合はenterを押して下さい: "
+aws s3 rm ${DELETE_S3_PATH} \
+  --recursive \
+  --profile ${PROFILE_NAME} \
+
+# 対象のComponentフォルダを削除
+rm -rf ${DELETE_DIR_PATH}

--- a/terraform/bin/init_s3.sh
+++ b/terraform/bin/init_s3.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# 実行スクリプトのフォルダへ移動（この記述をすることで実行場所を選ばないスクリプトになる）
+cd `dirname $0`
+
+read -p "tfstateを格納するS3バケット名を入力して下さい: " BUCKET_NAME
+read -p "S3バケット作成で使用するprofile名を入力してください: " PROFILE_NAME
+
+# バケットの作成
+echo "${BUCKET_NAME}の作成を行います"
+aws s3 mb s3://${BUCKET_NAME} \
+  --profile ${PROFILE_NAME}
+
+# バケットのバージョニング設定の変更
+printf '\r%50s' "${BUCKET_NAME}にバージョンニングを有効化します……"
+aws s3api put-bucket-versioning \
+  --profile ${PROFILE_NAME} \
+  --bucket ${BUCKET_NAME} \
+  --versioning-configuration Status=Enabled && \
+printf '\r%-50s\n' "${BUCKET_NAME}にバージョンニングを有効化に成功しました"
+
+# バケットのサーバー側の暗号化を設定
+printf '\r%50s' "${BUCKET_NAME}にサーバー側の暗号化を有効化します……"
+BUCKET_ENCRYPTION=`cat config/config-bucket-encryption.json`
+aws s3api put-bucket-encryption \
+  --profile ${PROFILE_NAME} \
+  --bucket ${BUCKET_NAME} \
+  --server-side-encryption-configuration "${BUCKET_ENCRYPTION}" && \
+printf '\r%-50s\n' "${BUCKET_NAME}にサーバー側の暗号化を有効化に成功しました"
+
+# バケットのアクセスに関する設定
+printf '\r%50s' "${BUCKET_NAME}のアクセスを変更します……"
+BUCKET_ACCESS_BLOCK=`cat config/config-public-access-block.json`
+aws s3api put-public-access-block \
+  --profile ${PROFILE_NAME} \
+  --bucket ${BUCKET_NAME} \
+  --public-access-block-configuration "${BUCKET_ACCESS_BLOCK}" && \
+printf '\r%-50s\n' "${BUCKET_NAME}のアクセスの変更に成功しました"

--- a/terraform/components/network/.terraform.lock.hcl
+++ b/terraform/components/network/.terraform.lock.hcl
@@ -1,0 +1,21 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "3.65.0"
+  constraints = "3.65.0"
+  hashes = [
+    "h1:hwHPvi/bvbNGOmMg2ECtU//klQBTgQBRFHAPaQ+LZoc=",
+    "zh:108aeaf5e18087d9ac852737a5be1347a28e40825817cc1a29ec523d40268294",
+    "zh:1a719c0c9754f906b2220d3bbf90d483ec0a74cf87768a464d2d657b7901ec6b",
+    "zh:21acdc35ae70a626cbc81eff06181a78843f1ddc2d9200f80fabf2e0466ecbda",
+    "zh:28846628e1a4227a1f2db256d6b22ed36922f37632999af7404aa74703cd9bfb",
+    "zh:32455550dbf86ae07d9782650e86d23c4fa13d7872e48680044692894e8da6ea",
+    "zh:4241246274627c752f9aef2806e810053306001e80fc5b51d27cbe997f75f95e",
+    "zh:5ca0fab3ceb3f41a97c1ebd29561a034cb83fda04da35fd5f8c3c5cb97bb3ea8",
+    "zh:5fed3b79d4ed6424055e8bbfb7a4393e8db5102cdba04b4590f8e0f4194637fb",
+    "zh:99a0bc325b0a59ded1152546c004953a2bb0e110978bf0cc55e1804384941bdb",
+    "zh:e74f9190a417c891992210f9af937ef55749d86a04762d982260fbbc989342a7",
+    "zh:fb6984405ca63d0373bd992ce157e933b8ae9dd94d74b1c5691632f062fe60b2",
+  ]
+}

--- a/terraform/components/network/.tool-versions
+++ b/terraform/components/network/.tool-versions
@@ -1,0 +1,1 @@
+terraform 1.1.4

--- a/terraform/components/network/internet_gateway.tf
+++ b/terraform/components/network/internet_gateway.tf
@@ -1,0 +1,8 @@
+resource "aws_internet_gateway" "igw" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name        = var.application
+    Description = format("IGW for creating %s resources", var.application)
+  }
+}

--- a/terraform/components/network/providers.tf
+++ b/terraform/components/network/providers.tf
@@ -1,0 +1,29 @@
+terraform {
+  required_version = "1.1.4"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.65.0"
+    }
+  }
+
+  backend "s3" {
+    region  = "ap-northeast-1"
+    encrypt = true
+    bucket  = "eroge-release-db"
+    key     = "network/terraform.tfstate"
+    profile = "terraform"
+  }
+}
+
+provider "aws" {
+  region  = var.aws_region
+  profile = var.aws_profile
+  default_tags {
+    tags = {
+      Component   = var.component
+      Application = var.application
+      Description = "VPC for creating ${var.application} resources"
+    }
+  }
+}

--- a/terraform/components/network/route_table.tf
+++ b/terraform/components/network/route_table.tf
@@ -1,0 +1,34 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name        = format("%s-public", var.application)
+    Description = format("Public route table for creating %s resources", var.application)
+  }
+}
+
+resource "aws_route_table" "private" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name        = format("%s-private", var.application)
+    Description = format("Private route table for creating %s resources", var.application)
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  count          = length(var.public_subnet_cidrs)
+  route_table_id = aws_route_table.public.id
+  subnet_id      = aws_subnet.public_subnet[count.index].id
+}
+
+resource "aws_route_table_association" "private" {
+  count          = length(var.private_subnet_cidrs)
+  route_table_id = aws_route_table.private.id
+  subnet_id      = aws_subnet.private_subnet[count.index].id
+}

--- a/terraform/components/network/subnet.tf
+++ b/terraform/components/network/subnet.tf
@@ -1,0 +1,23 @@
+resource "aws_subnet" "public_subnet" {
+  count             = length(var.public_subnet_cidrs)
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = element(var.public_subnet_cidrs, count.index)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name        = format("%s-public-%d%s", var.application, count.index + 1, substr(var.availability_zones[count.index], -1, -1))
+    Description = format("Public subnet for creating %s resources", var.application)
+  }
+}
+
+resource "aws_subnet" "private_subnet" {
+  count             = length(var.private_subnet_cidrs)
+  vpc_id            = aws_vpc.vpc.id
+  cidr_block        = element(var.private_subnet_cidrs, count.index)
+  availability_zone = var.availability_zones[count.index]
+
+  tags = {
+    Name        = format("%s-private-%d%s", var.application, count.index + 1, substr(var.availability_zones[count.index], -1, -1))
+    Description = format("Private subnet for creating %s resources", var.application)
+  }
+}

--- a/terraform/components/network/variables.tf
+++ b/terraform/components/network/variables.tf
@@ -29,3 +29,30 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.0.0.0/16"
 }
+
+variable "availability_zones" {
+  description = "Availability zones"
+  type        = list(string)
+  default = [
+    "ap-northeast-1a",
+    "ap-northeast-1c"
+  ]
+}
+
+variable "public_subnet_cidrs" {
+  description = "Public subnet - CIDR"
+  type        = list(string)
+  default = [
+    "10.0.11.0/24",
+    "10.0.12.0/24"
+  ]
+}
+
+variable "private_subnet_cidrs" {
+  description = "Private subnet - CIDR"
+  type        = list(string)
+  default = [
+    "10.0.21.0/24",
+    "10.0.22.0/24"
+  ]
+}

--- a/terraform/components/network/variables.tf
+++ b/terraform/components/network/variables.tf
@@ -1,0 +1,31 @@
+# Standard Variables
+variable "aws_region" {
+  description = "Target AWS Region"
+  type        = string
+  default     = "ap-northeast-1"
+}
+
+variable "aws_profile" {
+  description = "Local AWS Profile Name"
+  type        = string
+  default     = "terraform"
+}
+
+variable "application" {
+  description = "Application Name"
+  type        = string
+  default     = "eroge-release"
+}
+
+variable "component" {
+  description = "Network resource"
+  type        = string
+  default     = "network"
+}
+
+# VPC Variables
+variable "vpc_cidr" {
+  description = "VPC CIDR"
+  type        = string
+  default     = "10.0.0.0/16"
+}

--- a/terraform/components/network/vpc.tf
+++ b/terraform/components/network/vpc.tf
@@ -1,0 +1,8 @@
+resource "aws_vpc" "vpc" {
+  cidr_block = var.vpc_cidr
+
+  tags = {
+    Name        = var.application
+    Description = format("VPC for creating %s resources", var.application)
+  }
+}


### PR DESCRIPTION
## 概要

network 関連のリソースを Terraform 化する

## 修正内容

Terraformの実装ができるようにまずは tfstate ファイルを管理する S3 バケットを作成する
これは shellScript で作成する

以下のリソースを作成する

- VPC
- Subnet
- Route table
- Internet gateway

## 確認事項

- [ ] CIが通過していること
